### PR TITLE
Fix: Change selector in search results

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "google-search-results-shortcuts",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Keyboard shortcuts for google search results",
   "author": "Masaya Kazama <miyan@t-p.jp>",
   "private": true,

--- a/src/content/SearchResult.js
+++ b/src/content/SearchResult.js
@@ -2,7 +2,7 @@ let focusIndex = 0
 
 export default class SearchResult {
   get items () {
-    return Array.from(document.querySelectorAll('div > h3.r > a:first-child, td > a.pn'))
+    return Array.from(document.querySelectorAll('div > h3.r > a:first-of-type, td > a.pn'))
   }
   get nextPage () {
     return document.querySelector('#pnnext')


### PR DESCRIPTION
## current behavior
Focus does not match for `[pdf]`

## expected behavior
Focus will match for `[pdf]`
