### PR TITLE
Set cursor to the end

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "google-search-results-shortcuts",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Keyboard shortcuts for google search results",
   "author": "Masaya Kazama <miyan@t-p.jp>",
   "private": true,

--- a/src/content/index.js
+++ b/src/content/index.js
@@ -20,8 +20,10 @@ const focusUp = () => searchResult.focusPrev()
 const focusRight = () => searchResult.goNextPage()
 const focusLeft = () => searchResult.goPrevPage()
 const focusInput = () => {
+  const val = searchInput.value
+  searchInput.value = ''
   searchInput.focus()
-  searchInput.select()
+  searchInput.value = val
   return true
 }
 const keymap = {


### PR DESCRIPTION
When you want to add some words to the search query, you'll press the slash key and the whole of the query will be selected so that you will have to press the right-arrow key (that breaks your home position!) to move the cursor to the end of the query.
So I've fixed the focusInput() to set the cursor to the end as default.