### PR TITLE
Remove focusing on the pager

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "google-search-results-shortcuts",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "Keyboard shortcuts for google search results",
   "author": "Masaya Kazama <miyan@t-p.jp>",
   "private": true,

--- a/src/scripts/content/SearchResults.ts
+++ b/src/scripts/content/SearchResults.ts
@@ -1,7 +1,6 @@
 const anchor = 'a:first-of-type'
 const linkSelector = [
-  ...['.r > g-link', 'div > .r'].map(container => `${container} > ${anchor}`),
-  'td > a.pn'
+  ...['.r > g-link', 'div > .r'].map(container => `${container} > ${anchor}`)
 ].join(',')
 
 const kpLinkSelector = ['g-link', '.r']


### PR DESCRIPTION
## Why

- It's useless because you can move pages with left / right keys.
