### PR TITLE
fix: Style fix for focus content

### DIFF
--- a/src/scripts/content/SearchResults.ts
+++ b/src/scripts/content/SearchResults.ts
@@ -83,7 +83,7 @@ export class SearchResults {
     target.focus()
 
     const content = `${this.focusIndex + 1}/${links.length} ▶`
-    this.style.innerHTML = `a:focus::before {
+    this.style.innerHTML = `.g a:focus::before {
       content: "${content}";
       font-size: 16px;
       white-space: nowrap;

--- a/src/scripts/content/SearchResults.ts
+++ b/src/scripts/content/SearchResults.ts
@@ -85,12 +85,6 @@ export class SearchResults {
     const content = `${this.focusIndex + 1}/${links.length} ▶`
     this.style.innerHTML = `[data-gsrks-focused]:focus::before {
       content: "${content}";
-      font-size: 16px;
-      white-space: nowrap;
-      position: absolute;
-      right: 100%;
-      top: 0;
-      transform: translate(-8px);
     }`
     return target
   }

--- a/src/scripts/content/SearchResults.ts
+++ b/src/scripts/content/SearchResults.ts
@@ -16,7 +16,7 @@ export class SearchResults {
     this.style = style
 
     this.links.forEach(el => {
-      el.setAttribute('data-gsrks-focused', '')
+      el.setAttribute('data-gsrks-anchor', '')
     })
   }
 
@@ -87,7 +87,7 @@ export class SearchResults {
     target.focus()
 
     const content = `${this.focusIndex + 1}/${links.length} ▶`
-    this.style.innerHTML = `[data-gsrks-focused]:focus::before {
+    this.style.innerHTML = `[data-gsrks-anchor]:focus::before {
       content: "${content}";
     }`
     return target

--- a/src/scripts/content/SearchResults.ts
+++ b/src/scripts/content/SearchResults.ts
@@ -83,7 +83,7 @@ export class SearchResults {
     target.focus()
 
     const content = `${this.focusIndex + 1}/${links.length} ▶`
-    this.style.innerHTML = `.g a:focus::before {
+    this.style.innerHTML = `[data-gsrks-focused]:focus::before {
       content: "${content}";
       font-size: 16px;
       white-space: nowrap;

--- a/src/scripts/content/SearchResults.ts
+++ b/src/scripts/content/SearchResults.ts
@@ -14,6 +14,10 @@ export class SearchResults {
     const style = document.createElement('style')
     document.body.appendChild(style)
     this.style = style
+
+    this.links.forEach(el => {
+      el.setAttribute('data-gsrks-focused', '')
+    })
   }
 
   get links(): HTMLAnchorElement[] {

--- a/src/scripts/content/index.scss
+++ b/src/scripts/content/index.scss
@@ -2,7 +2,7 @@ $focusColor: 0px 0px 0px 4px rgba(26, 13, 171, 0.1);
 $focusTransform: translate(-1em, -0.1em);
 $focusTransition: ease-out 0.1s;
 
-[data-gsrks-focused]:focus {
+[data-gsrks-anchor]:focus {
   outline: none;
   position: relative;
   display: inline-block;

--- a/src/scripts/content/index.scss
+++ b/src/scripts/content/index.scss
@@ -2,7 +2,7 @@ $focusColor: 0px 0px 0px 4px rgba(26, 13, 171, 0.1);
 $focusTransform: translate(-1em, -0.1em);
 $focusTransition: ease-out 0.1s;
 
-a:focus {
+.g a:focus {
   outline: none;
   position: relative;
   display: inline-block;

--- a/src/scripts/content/index.scss
+++ b/src/scripts/content/index.scss
@@ -11,4 +11,12 @@ $focusTransition: ease-out 0.1s;
   cite {
     white-space: nowrap;
   }
+  &::before{
+    font-size: 16px;
+    white-space: nowrap;
+    position: absolute;
+    right: 100%;
+    top: 0;
+    transform: translate(-8px);
+  }
 }

--- a/src/scripts/content/index.scss
+++ b/src/scripts/content/index.scss
@@ -2,7 +2,7 @@ $focusColor: 0px 0px 0px 4px rgba(26, 13, 171, 0.1);
 $focusTransform: translate(-1em, -0.1em);
 $focusTransition: ease-out 0.1s;
 
-.g a:focus {
+[data-gsrks-focused]:focus {
   outline: none;
   position: relative;
   display: inline-block;

--- a/src/scripts/content/index.ts
+++ b/src/scripts/content/index.ts
@@ -106,10 +106,15 @@ const activateKeyHandler = (isActive: boolean) => {
 const init = () => {
   // if (searchResult.isEmpty) return
   const formInputs = document.querySelectorAll('input, textarea')
+  const h3 = document.querySelectorAll('h3')
 
   formInputs.forEach(el => {
     el.addEventListener('focusin', () => activateKeyHandler(false))
     el.addEventListener('focusout', () => activateKeyHandler(true))
+  })
+
+  h3.forEach(el => {
+    el.closest('a')?.setAttribute('data-gsrks-focused', '')
   })
 
   activateKeyHandler(true)

--- a/src/scripts/content/index.ts
+++ b/src/scripts/content/index.ts
@@ -104,17 +104,11 @@ const activateKeyHandler = (isActive: boolean) => {
 }
 
 const init = () => {
-  // if (searchResult.isEmpty) return
   const formInputs = document.querySelectorAll('input, textarea')
-  const h3 = document.querySelectorAll('h3')
 
   formInputs.forEach(el => {
     el.addEventListener('focusin', () => activateKeyHandler(false))
     el.addEventListener('focusout', () => activateKeyHandler(true))
-  })
-
-  h3.forEach(el => {
-    el.closest('a')?.setAttribute('data-gsrks-focused', '')
   })
 
   activateKeyHandler(true)


### PR DESCRIPTION
## 修正したい点
`a` タグの全体に対して `style` が適用されているため、修正する方向でやっていきたいです。

## 課題の参考イメージ
<img width="1057" alt="スクリーンショット 2020-10-01 23 18 08" src="https://user-images.githubusercontent.com/2557813/94821393-802e5100-043c-11eb-823c-dd7e7726dd22.png">

<img width="403" alt="スクリーンショット 2020-10-01 22 05 31" src="https://user-images.githubusercontent.com/2557813/94822974-42cac300-043e-11eb-89c5-7f5c64e754f1.png">
