### PR TITLE
アコーディオン内はフォーカス対象から除外する

### DIFF
--- a/src/content-scripts/searchResult.ts
+++ b/src/content-scripts/searchResult.ts
@@ -4,7 +4,7 @@ const ignoreWrapperList = [
   "g-expandable-container",
   "g-accordion-expander",
   "g-scrolling-carousel",
-  "[jscontroller]",
+  "[jsslot]",
 ];
 
 let focusedIndex = 0;

--- a/src/content-scripts/searchResult.ts
+++ b/src/content-scripts/searchResult.ts
@@ -4,6 +4,7 @@ const ignoreWrapperList = [
   "g-expandable-container",
   "g-accordion-expander",
   "g-scrolling-carousel",
+  "[jscontroller]",
 ];
 
 let focusedIndex = 0;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1443118/168465705-626bd6ad-57e1-4aa0-a8cb-d01a88d2e2a6.png)

## 問題

アコーディオン内のlinkにフォーカスしてしまう

## 対応

jscontroller属性がある要素（赤線で表示）はフォーカス対象から除外する